### PR TITLE
Match github urls using git: http: or https: schemes

### DIFF
--- a/lib/Dist/Zilla/Plugin/Repository.pm
+++ b/lib/Dist/Zilla/Plugin/Repository.pm
@@ -153,7 +153,7 @@ sub _find_repo {
 
             $repo{url} = $git_url unless $git_url eq 'origin'; # RT 55136
 
-            if ( $git_url =~ /^git:\/\/(github\.com.*?)\.git$/ ) {
+            if ( $git_url =~ /^(?:git|https?):\/\/(github\.com.*?)\.git$/ ) {
                 $repo{web} = "http://$1";
 
                 if ($self->github_http) {


### PR DESCRIPTION
I had a remote using the http: scheme and the regexp didn't match
so the plugin didn't save the 'web' parameter.
I thought this was a fairly simple change to enable it,
though I don't know if it's appropriate or if it /should/ only work for git: schemes.
