### PR TITLE
Use https:// for Github web URLs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Dist-Zilla-Plugin-Repository
 
+0.19
+        Use https:// URLs for Github. (DOLMEN)
+
 0.18    2011.04.23
         Match github urls using git: http: or https: schemes (magnificent-tears)
 

--- a/lib/Dist/Zilla/Plugin/Repository.pm
+++ b/lib/Dist/Zilla/Plugin/Repository.pm
@@ -26,8 +26,8 @@ you use Git). By default, unsurprisingly, to F<origin>.
 =item * github_http
 
 B<This attribute is deprecated.>
-If the remote is a GitHub repository, list only the http url
-(http://github.com/fayland/dist-zilla-plugin-repository) and not the actual
+If the remote is a GitHub repository, list only the https url
+(https://github.com/fayland/dist-zilla-plugin-repository) and not the actual
 clonable url (git://github.com/fayland/dist-zilla-plugin-repository.git).
 This used to default to true, but as of 0.16 it defaults to false.
 
@@ -154,10 +154,10 @@ sub _find_repo {
             $repo{url} = $git_url unless $git_url eq 'origin'; # RT 55136
 
             if ( $git_url =~ /^(?:git|https?):\/\/(github\.com.*?)\.git$/ ) {
-                $repo{web} = "http://$1";
+                $repo{web} = "https://$1";
 
                 if ($self->github_http) {
-                  # I prefer http://github.com/user/repository
+                  # I prefer https://github.com/user/repository
                   # to git://github.com/user/repository.git
                   delete $repo{url};
                   $self->log("github_http is deprecated.  ".

--- a/t/10-repo.t
+++ b/t/10-repo.t
@@ -187,7 +187,7 @@ sub remote_not_found
       $tzil->distmeta->{resources}{repository},
       { type => 'git',
         url => 'git://github.com/fayland/dist-zilla-plugin-repository.git',
-        web => 'http://github.com/fayland/dist-zilla-plugin-repository' },
+        web => 'https://github.com/fayland/dist-zilla-plugin-repository' },
       "Auto github"
   );
   ok(!github_deprecated($tzil), "Auto github log message");
@@ -200,7 +200,7 @@ sub remote_not_found
   is_deeply(
       $tzil->distmeta->{resources}{repository},
       { type => 'git',
-        web => 'http://github.com/fayland/dist-zilla-plugin-repository' },
+        web => 'https://github.com/fayland/dist-zilla-plugin-repository' },
       "Auto github with http"
   );
   ok(github_deprecated($tzil), "Auto github with http log message");
@@ -214,7 +214,7 @@ sub remote_not_found
       $tzil->distmeta->{resources}{repository},
       { type => 'git',
         url => 'git://github.com/fayland/dist-zilla-plugin-repository.git',
-        web => 'http://github.com/fayland/dist-zilla-plugin-repository' },
+        web => 'https://github.com/fayland/dist-zilla-plugin-repository' },
       "Auto github no http"
   );
   ok(!github_deprecated($tzil), "Auto github no http log message");
@@ -227,7 +227,7 @@ sub remote_not_found
   is_deeply(
       $tzil->distmeta->{resources}{repository},
       { type => 'git',
-        web => 'http://github.com/rjbs/dist-zilla' },
+        web => 'https://github.com/rjbs/dist-zilla' },
       "Auto github remote dzil with github_http"
   );
   ok(github_deprecated($tzil),
@@ -242,7 +242,7 @@ sub remote_not_found
       $tzil->distmeta->{resources}{repository},
       { type => 'git',
         url => 'git://github.com/rjbs/dist-zilla.git',
-        web => 'http://github.com/rjbs/dist-zilla' },
+        web => 'https://github.com/rjbs/dist-zilla' },
       "Auto github remote dzil no http"
   );
   ok(!github_deprecated($tzil), "Auto github remote dzil no http log message");


### PR DESCRIPTION
http:// Github URLs now always redirect to https://
So generate https:// for CPAN meta.
