### PR TITLE
fix: Create correct metadata with only a repository

### DIFF
--- a/t/10-repo.t
+++ b/t/10-repo.t
@@ -444,4 +444,17 @@ END GITHUB REMOTE NOT FOUND
 }
 
 #---------------------------------------------------------------------
+{
+  my $tzil = build_tzil(['repository = git@gitlab.com:foo/bar.git'], '.git');
+
+  is_deeply(
+      $tzil->distmeta->{resources}{repository},
+      { type => 'git',
+        url => 'git://gitlab.com/foo/bar.git',
+        web => 'https://gitlab.com/foo/bar' },
+      "Auto gitlab"
+  );
+  ok(!github_deprecated($tzil), "Auto gitlab log message");
+}
+
 done_testing;


### PR DESCRIPTION
Allow a user to set

    [Reposity]
    repository = git@gitlab.com:foo/bar.git

And then have nice metadata in META-files