### PR TITLE
Support all repositories as having issue/web/etc

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ copyright_holder = Fayland Lam, Ricardo SIGNES, Moritz Onken, Christopher J. Mad
 [Prereqs]
 Dist::Zilla = 4.102340
 Moose = 0
+URI::git = 0
 
 [Prereqs / TestRequires]
 Dist::Zilla::Tester = 4.102340

--- a/lib/Dist/Zilla/Plugin/Repository.pm
+++ b/lib/Dist/Zilla/Plugin/Repository.pm
@@ -3,6 +3,7 @@ package Dist::Zilla::Plugin::Repository;
 # ABSTRACT: Automatically sets repository URL from svn/svk/Git checkout for Dist::Zilla
 
 use Moose;
+use URI;
 with 'Dist::Zilla::Role::MetaProvider';
 
 =head1 SYNOPSIS
@@ -147,26 +148,22 @@ sub _git_to_repo {
 
     $uri =~ s![\w\-]+\@([^:]+):!git://$1/!;
 
+    return if $uri !~ m#^\w+://#;
+
     my %repo = (type => 'git');
 
-    $repo{url} = $uri unless $uri eq 'origin';    # RT 55136
+    $uri = URI->new($uri);
+    $repo{web} = "https://" . $uri->host . $uri->path =~ s/\.git$//r;
+    $repo{url} = "$uri";
 
-    if ($uri
-        =~ /^(?:git|https?):\/\/((?:git(?:lab|hub)\.com|bitbucket.org).*?)(?:\.git)?$/
-        )
-    {
-        $repo{web} = "https://$1";
-
-        if ($self->github_http) {
-
-            # I prefer https://github.com/user/repository
-            # to git://github.com/user/repository.git
-            delete $repo{url};
-            $self->log("github_http is deprecated.  "
-                    . "Consider using META.json instead,\n"
-                    . "which can store URLs for both git clone "
-                    . "and the web front-end.");
-        }
+    if ($self->github_http) {
+        # I prefer https://github.com/user/repository
+        # to git://github.com/user/repository.git
+        delete $repo{url};
+        $self->log("github_http is deprecated.  "
+                . "Consider using META.json instead,\n"
+                . "which can store URLs for both git clone "
+                . "and the web front-end.");
     }
     return %repo;
 }

--- a/lib/Dist/Zilla/Plugin/Repository.pm
+++ b/lib/Dist/Zilla/Plugin/Repository.pm
@@ -181,10 +181,10 @@ sub _find_repo {
         if ($self->has_repository) {
             %repo = $self->_git_to_repo($self->repository);
         }
-        elsif ($execute->('git remote show -n ' . $self->git_remote)
-            =~ /URL: (.*)$/m)
+        elsif (my $url = $execute->('git config get remote.' .
+            $self->git_remote . '.url'))
         {
-            %repo = $self->_git_to_repo($1);
+            %repo = $self->_git_to_repo($url);
         }
         elsif ($execute->('git svn info') =~ /URL: (.*)$/m) {
             %repo = (qw(type svn  url), $1);

--- a/t/10-repo.t
+++ b/t/10-repo.t
@@ -26,33 +26,20 @@ my %result;
   }
 }
 
-$result{'git remote show -n origin'} = <<'END GIT';
-* remote origin
-  Fetch URL: git@github.com:fayland/dist-zilla-plugin-repository.git
-  Push  URL: git@github.com:fayland/dist-zilla-plugin-repository.git
-  HEAD branch: (not queried)
-  Remote branch: (status not queried)
-    master
-  Local branch configured for 'git pull':
-    master merges with remote master
-  Local ref configured for 'git push' (status not queried):
-    (matching) pushes to (matching)
-END GIT
+my %remotes = (
+  origin    => 'git@github.com:fayland/dist-zilla-plugin-repository.git',
+  dzil      => 'git://github.com/rjbs/dist-zilla.git',
+  bitbucket => 'git@bitbucket.org:foo/bar',
+  codeberg  => 'ssh://git@codeberg.org/foo/bar.git',
+  gitlab    => 'git@gitlab.com:foo/bar',
+  github    => 'git@github.com:foo/bar',
+  work      => 'work',
+  nourl     => 'origin',
+);
 
-$result{'git remote show -n dzil'} = <<'END GIT DZIL';
-* remote dzil
-  Fetch URL: git://github.com/rjbs/dist-zilla.git
-  Push  URL: git://github.com/rjbs/dist-zilla.git
-  HEAD branch: (not queried)
-  Remote branches: (status not queried)
-    config-mvp-reader
-    cpan-meta-prereqs
-    master
-    new-classic
-    prereq-overhaul
-  Local ref configured for 'git push' (status not queried):
-    (matching) pushes to (matching)
-END GIT DZIL
+foreach (keys %remotes) {
+  $result{"git config get remote.$_.url"} = $remotes{$_};
+}
 
 $result{'svn info'} = <<'END SVN';
 Path: .
@@ -80,32 +67,6 @@ END DARCS
 $result{'hg paths'} = <<'END HG';
 default = https://foobar.googlecode.com/hg/
 END HG
-
-$result{'git remote show -n gitlab'} = <<'END GITLAB';
-* remote origin
-  Fetch URL: git@gitlab.com:foo/bar
-  Push  URL: git@gitlab.com:foo/bar
-  HEAD branch: (not queried)
-  Remote branch: (status not queried)
-    master
-  Local branch configured for 'git pull':
-    master merges with remote master
-  Local ref configured for 'git push' (status not queried):
-    (matching) pushes to (matching)
-END GITLAB
-
-$result{'git remote show -n bitbucket'} = <<'END BITBUCKET';
-* remote origin
-  Fetch URL: git@bitbucket.org:foo/bar
-  Push  URL: git@bitbucket.org:foo/bar
-  HEAD branch: (not queried)
-  Remote branch: (status not queried)
-    master
-  Local branch configured for 'git pull':
-    master merges with remote master
-  Local ref configured for 'git push' (status not queried):
-    (matching) pushes to (matching)
-END BITBUCKET
 
 #---------------------------------------------------------------------
 sub make_ini

--- a/t/10-repo.t
+++ b/t/10-repo.t
@@ -351,14 +351,6 @@ sub remote_not_found
 }
 
 #---------------------------------------------------------------------
-$result{'git remote show -n nourl'} = <<'END GIT NOURL';
-* remote nourl
-  Fetch URL: origin
-  Push  URL: origin
-  HEAD branch: (not queried)
-  Remote branches: (status not queried)
-END GIT NOURL
-
 {
   my $tzil = build_tzil(['git_remote = nourl'], '.git');
 
@@ -376,32 +368,23 @@ END GIT NOURL
 
   is_deeply(
       $tzil->distmeta->{resources}{repository},
-      { type => 'git',  url => $url },
+      { type => 'git',  url => $url, web => 'https://example.com/example' },
       "Auto git remote nourl with repository"
   );
   ok(!github_deprecated($tzil),
      "Auto git remote nourl with repository log message");
 }
 
-#---------------------------------------------------------------------
-$result{'git remote show -n github'} = <<'END GITHUB REMOTE NOT FOUND';
-* remote github
-  Fetch URL: github
-  Push  URL: github
-  HEAD branch: (not queried)
-  Remote branches: (status not queried)
-END GITHUB REMOTE NOT FOUND
-
 {
-  my $tzil = build_tzil(['git_remote = github'], '.git');
+  my $tzil = build_tzil(['git_remote = work'], '.git');
 
   is(
       $tzil->distmeta->{resources}{repository},
       undef,
-      "Auto git remote github not found"
+      "Auto git remote work not found"
   );
-  ok(remote_not_found($tzil),
-      "Auto git remote github not found");
+  ok(!remote_not_found($tzil),
+      "Auto git remote work not found");
 }
 
 #---------------------------------------------------------------------
@@ -418,4 +401,16 @@ END GITHUB REMOTE NOT FOUND
   ok(!github_deprecated($tzil), "Auto gitlab log message");
 }
 
+{
+  my $tzil = build_tzil(['repository = git@codeberg.org:foo/bar.git'], '.git');
+
+  is_deeply(
+      $tzil->distmeta->{resources}{repository},
+      { type => 'git',
+        url => 'git://codeberg.org/foo/bar.git',
+        web => 'https://codeberg.org/foo/bar' },
+      "Auto codeberg"
+  );
+  ok(!github_deprecated($tzil), "Auto codeberg log message");
+}
 done_testing;


### PR DESCRIPTION
This commit introduces URI::git as a helper to get the hostname and the
path of the repo and we build the web URL with these values.

I didn't want to have a list of all forges to whitelist:

GitHub, GitLab, Bitbucket, Codeberg, SourceHut, Gitea/Forgejo,
Launchpad, Savannah, etc.

The upside is, this module now "knows" all forges, the downside is,
example.com, now also have a web. I personally don't have an
issue with this logic as you use this module intentionally to create the
CPAN metadata. So I went along and skipped the whitelisting of forges.